### PR TITLE
Make cas0 throw a more specific exception when there is no value.

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -44,6 +44,7 @@ import net.rubyeye.xmemcached.command.CommandType;
 import net.rubyeye.xmemcached.command.ServerAddressAware;
 import net.rubyeye.xmemcached.command.TextCommandFactory;
 import net.rubyeye.xmemcached.exception.MemcachedException;
+import net.rubyeye.xmemcached.exception.NoValueException;
 import net.rubyeye.xmemcached.impl.ArrayMemcachedSessionLocator;
 import net.rubyeye.xmemcached.impl.ClosedMemcachedTCPSession;
 import net.rubyeye.xmemcached.impl.DefaultKeyProvider;
@@ -1702,7 +1703,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 		int tryCount = 0;
 		GetsResponse<T> result = getsResponse;
 		if (result == null) {
-			throw new MemcachedException("Null GetsResponse");
+			throw new NoValueException("Null GetsResponse for key=" + key);
 		}
 		while (tryCount <= operation.getMaxTries()
 				&& result != null
@@ -1716,7 +1717,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 			tryCount++;
 			result = this.gets0(key, keyBytes, transcoder);
 			if (result == null) {
-				throw new MemcachedException(
+				throw new NoValueException(
 						"could not gets the value for Key=" + key + " for cas");
 			}
 			if (tryCount > operation.getMaxTries()) {

--- a/src/main/java/net/rubyeye/xmemcached/exception/NoValueException.java
+++ b/src/main/java/net/rubyeye/xmemcached/exception/NoValueException.java
@@ -1,0 +1,38 @@
+/**
+ *Copyright [2009-2010] [dennis zhuang(killme2008@gmail.com)]
+ *Licensed under the Apache License, Version 2.0 (the "License");
+ *you may not use this file except in compliance with the License. 
+ *You may obtain a copy of the License at 
+ *             http://www.apache.org/licenses/LICENSE-2.0 
+ *Unless required by applicable law or agreed to in writing, 
+ *software distributed under the License is distributed on an "AS IS" BASIS, 
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+ *either express or implied. See the License for the specific language governing permissions and limitations under the License
+ */
+package net.rubyeye.xmemcached.exception;
+
+/**
+ * Memcached Client Exception
+ * @author bmahe
+ *
+ */
+public class NoValueException extends MemcachedClientException {
+
+	public NoValueException() {
+		super();
+	}
+
+	public NoValueException(String s) {
+		super(s);
+	}
+
+	public NoValueException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NoValueException(Throwable cause) {
+		super(cause);
+	}
+
+	private static final long serialVersionUID = -8717259791309127913L;
+}


### PR DESCRIPTION
This is useful when a key happens to have expired in between calls
